### PR TITLE
Fix: VersionId not being applied for GetObject

### DIFF
--- a/nodes/get-object/get-object.js
+++ b/nodes/get-object/get-object.js
@@ -79,8 +79,9 @@ function inputHandler(n, RED) {
     // Version ID parameter
     let versionid = n.versionid != "" ? n.versionid : null;
     if (!versionid) {
-      payloadConfig.VersionId = msgClone.versionid ? msgClone.versionid : null;
+      versionid = msgClone.versionid ? msgClone.versionid : null;
     }
+    payloadConfig.VersionId = versionid;
 
     // Stringify body parameter
     let stringifybody = n.stringifybody ? n.stringifybody : false;


### PR DESCRIPTION
This PR fixes a bug where VersionId is being ignored when being set in the GUI for the GetObject node (setting it on the **msg** object works fine). 